### PR TITLE
Replace Caddy with Traefik as reverse proxy and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,6 @@ SUBDOMAIN=n8n
 # If not set New York time will be used (e.g., Europe/Amsterdam, America/New_York)                                     
 GENERIC_TIMEZONE=Europe/Amsterdam                                                                                      
                                                                                                                        
-# The email address to use for the Let's Encrypt SSL certificate creation                                              
-SSL_EMAIL=user@example.com                                                                                             
-                                                                                                                       
 # PostgreSQL Settings (e.g., from Neon.tech)                                                                           
 # Find these details in your Neon project dashboard                                                                    
 DB_POSTGRESDB_HOST=ep-xxxxxxxx-xxxxxx-pooler.xx.xx.neon.tech                                                           

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ backend. It's configured to use an external PostgreSQL database (like Neon.tech)
     *   `DOMAIN_NAME`: Your top-level domain (e.g., `example.com`).                                                        
     *   `SUBDOMAIN`: The subdomain for n8n (e.g., `n8n`, resulting in `n8n.example.com`).                                  
     *   `GENERIC_TIMEZONE`: Your timezone (e.g., `Europe/Amsterdam`).                                                      
-good practice).                                                                                                            
+*   `GENERIC_TIMEZONE`: Your timezone (e.g., `Europe/Amsterdam`).
     *   `DB_POSTGRESDB_HOST`: Hostname of your PostgreSQL database.                                                        
     *   `DB_POSTGRESDB_PORT`: Port of your PostgreSQL database (usually `5432`).                                           
     *   `POSTGRES_USER`: Username for your PostgreSQL database.                                                            

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ backend. It's configured to use an external PostgreSQL database (like Neon.tech)
     *   `DOMAIN_NAME`: Your top-level domain (e.g., `example.com`).                                                        
     *   `SUBDOMAIN`: The subdomain for n8n (e.g., `n8n`, resulting in `n8n.example.com`).                                  
     *   `GENERIC_TIMEZONE`: Your timezone (e.g., `Europe/Amsterdam`).                                                      
-    *   `SSL_EMAIL`: Email for SSL certificate registration (though Traefik isn't configured for Let's Encrypt here, it's  
 good practice).                                                                                                            
     *   `DB_POSTGRESDB_HOST`: Hostname of your PostgreSQL database.                                                        
     *   `DB_POSTGRESDB_PORT`: Port of your PostgreSQL database (usually `5432`).                                           

--- a/caddy_config/Caddyfile
+++ b/caddy_config/Caddyfile
@@ -1,5 +1,0 @@
-n8n.example.com {
-    reverse_proxy n8n:5678 {
-      flush_interval -1
-    }
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
     environment: # see https://doc.traefik.io/traefik/reference/static-configuration/env/ for reference on each variable used below
       # see https://github.com/traefik/traefik/issues/3870#issuecomment-501566619 for explanation of this variable
       - TZ=${GENERIC_TIMEZONE}
-    command: 
-      - --api.insecure=true 
-      - --providers.docker 
+    command:
+      - --api.insecure=true
+      - --providers.docker
       - --accesslog=true
     labels:
       - "traefik.enable=false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,5 @@ services:
       - puppeteer_data:/home/node/.cache/puppeteer
 
 volumes:
-  caddy_data:
   n8n_data:
   puppeteer_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,26 @@
-version: "3.7"
-
 networks:
   n8n-network:
     driver: bridge
 
 services:
-  caddy:
-    image: caddy:latest
+  traefik:
+    image: traefik:v3
+    restart: unless-stopped
+    environment: # see https://doc.traefik.io/traefik/reference/static-configuration/env/ for reference on each variable used below
+      # see https://github.com/traefik/traefik/issues/3870#issuecomment-501566619 for explanation of this variable
+      - TZ=${GENERIC_TIMEZONE}
+    command: 
+      - --api.insecure=true 
+      - --providers.docker 
+      - --accesslog=true
+    labels:
+      - "traefik.enable=false"
+    ports: # HTTPS is handled by Cloudflare DNS Proxy, so we only need HTTP here
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - n8n-network
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - caddy_data:/data
-      - ./caddy_config:/config
-      - ./caddy_config/Caddyfile:/etc/caddy/Caddyfile
     depends_on:
       - n8n
 
@@ -27,6 +31,9 @@ services:
     restart: always
     ports:
       - 5678:5678
+    labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)"
     environment:
       - N8N_HOST=${SUBDOMAIN}.${DOMAIN_NAME}
       - N8N_PORT=5678

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,8 @@ services:
       - TZ=${GENERIC_TIMEZONE}
     command:
       - --api.insecure=true
-      - --providers.docker
+      - --providers.docker.exposedByDefault=false
       - --accesslog=true
-    labels:
-      - "traefik.enable=false"
     ports: # HTTPS is handled by Cloudflare DNS Proxy, so we only need HTTP here
       - "80:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
     ports:
       - 5678:5678
     labels:
-    - "traefik.enable=true"
-    - "traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)"
+      - "traefik.enable=true"
+      - "traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)"
     environment:
       - N8N_HOST=${SUBDOMAIN}.${DOMAIN_NAME}
       - N8N_PORT=5678


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Completely rewrote the README to reflect the new setup using Traefik instead of Caddy, updated prerequisites, setup, and usage instructions, and clarified HTTPS handling.
  - Added a components section and simplified the license section.

- **Chores**
  - Removed Caddy configuration and related volumes.
  - Updated Docker Compose to replace Caddy with Traefik, including new service definitions and routing labels.
  - Removed SSL email environment variable from example configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->